### PR TITLE
Fix broken links

### DIFF
--- a/source/docs/a1.why_rust.md
+++ b/source/docs/a1.why_rust.md
@@ -12,7 +12,7 @@ The goal of Rust is to be a good language for creating highly concurrent and hig
 
 Rust is very young and very modern language. It's a **compiled programming language** and it uses [LLVM](https://en.wikipedia.org/wiki/LLVM) on its backend. Also Rust is a **multi-paradigm programming language**, it supports imperative procedural, concurrent actor, object-oriented and pure functional styles. It also supports generic programming and meta programming, in both static and dynamic styles.
 
-> 🔎 One of Rust’s most unique and compelling features is [Ownership](c1.ownership.md), which uses to achieves memory safety. Rust creates memory pointers optimistically, checks memory pointers’ limited accesses at the compiler time with the usage of [References and Borrowing](c2.borrowing.md). And it does automatic compile time memory management by checking the [Lifetimes](c3.lifetimes.md).
+> 🔎 One of Rust’s most unique and compelling features is [Ownership](c1.ownership.html), which uses to achieves memory safety. Rust creates memory pointers optimistically, checks memory pointers’ limited accesses at the compiler time with the usage of [References and Borrowing](c2.borrowing.html). And it does automatic compile time memory management by checking the [Lifetimes](c3.lifetimes.html).
 
 ## Influences
 Its design elements came from a wide range of sources.

--- a/source/docs/a9.operators.md
+++ b/source/docs/a9.operators.md
@@ -110,4 +110,4 @@ let b = (a as f64) / 2.0; //7.5
 
 The **& or &mut** operators are used for **borrowing** and ***** operator for **Dereferencing**.
 
-> 🔎 For more information, refer [Ownership](c1.ownership.md), [Borrowing](c2.borrowing.md) & [Lifetimes](c3.lifetimes.md) sections.
+> 🔎 For more information, refer [Ownership](c1.ownership.html), [Borrowing](c2.borrowing.html) & [Lifetimes](c3.lifetimes.html) sections.


### PR DESCRIPTION
Fixes some 404s -- they were linking to `.md` but the `hexo` builds them as `.html`.