### PR TITLE
Removed space before comma

### DIFF
--- a/source/docs/a6.variable_bindings,constants_and_statics.md
+++ b/source/docs/a6.variable_bindings,constants_and_statics.md
@@ -1,4 +1,4 @@
-title: Variable bindings , Constants & Statics
+title: Variable bindings, Constants & Statics
 ---
 
 ⭐️ In Rust variables are **immutable by default**, so we call them **Variable bindings**. To make them mutable, `mut` keyword is used.


### PR DESCRIPTION
The white space before the comma is incorrect for this language (English).