### PR TITLE
fixed warning: `...` range patterns are deprecated to `..=`

### DIFF
--- a/source/docs/a10.control_flows.md
+++ b/source/docs/a10.control_flows.md
@@ -51,7 +51,7 @@ let tshirt_width = 20;
 let tshirt_size = match tshirt_width {
     16 => "S", // check 16
     17 | 18 => "M", // check 17 and 18
-    19 ... 21 => "L", // check from 19 to 21 (19,20,21)
+    19 ..= 21 => "L", // check from 19 to 21 (19,20,21)
     22 => "XL",
     _ => "Not Available",
 };

--- a/source/docs/e2.panicking.md
+++ b/source/docs/e2.panicking.md
@@ -96,9 +96,9 @@ This is the standard macro to mark **routes that the program should not enter**.
 fn main() {
     let level = 22;
     let stage = match level {
-        1...5 => "beginner",
-        6...10 => "intermediate",
-        11...20 => "expert",
+        1..=5 => "beginner",
+        6..=10 => "intermediate",
+        11..=20 => "expert",
         _ => unreachable!(),
     };
     


### PR DESCRIPTION
i'm beginner, but when i tried `match` section, i found `warning: `...` range patterns are deprecated`. and then, the rust help show `..=` for solved it. i used rustc 1.40.0 (73528e339 2019-12-16) for tired `match` section. thank you.