### PR TITLE
Updated slice in a8.primitive_data_types.md

### DIFF
--- a/source/docs/a8.primitive_data_types.md
+++ b/source/docs/a8.primitive_data_types.md
@@ -145,10 +145,10 @@ Imagine you want to get/ pass a part of an array or any other data structure. In
 let a: [i32; 4] = [1, 2, 3, 4]; // Parent Array
 
 let b: &[i32] = &a; // Slicing whole array
-let c = &a[0..4]; // From 0th position to 4th(excluding)
+let c = &a[0..3]; // From 0th position to 4th(excluding)
 let d = &a[..]; // Slicing whole array
 
-let e = &a[1..3]; // [2, 3]
+let e = &a[1..2]; // [2, 3]
 let f = &a[1..]; // [2, 3, 4]
 let g = &a[..3]; // [1, 2, 3]
 ```


### PR DESCRIPTION
The index mentioned in example for slice in incorrect. Array index start from 0 and end with length-1.
I think there is mind manipulation mistake in mentioning index.