### PR TITLE
style: Fix Page scrollbar blindness

### DIFF
--- a/themes/navy/source/css/_partial/page.styl
+++ b/themes/navy/source/css/_partial/page.styl
@@ -117,7 +117,7 @@ note-warn = hsl(0, 100%, 50%)
 .article-content
   line-height: line-height
   color: color-default
-  overflow-x: scroll
+  overflow-x: auto
   @media print
     font-size: 12pt
   p, ol, ul, dl, table, blockquote, iframe, .highlight


### PR DESCRIPTION
Great project!

Very minor contribution, but on Linux/Windows having overflow-x set to scroll, paints the scrollbar. This is something Macbook users won't see. Check https://svenkadak.com/blog/scrollbar-blindness for an in-depth explanation.