### PR TITLE
Update some text about borrow checking for accuracy

### DIFF
--- a/content/en/docs/c3.lifetimes.md
+++ b/content/en/docs/c3.lifetimes.md
@@ -23,9 +23,9 @@ In Rust,
 * When dealing with **references**, we have to specify **lifetime annotations** to provide instructions for the **compiler** to set **how long** those referenced resources **should be alive**.
 * ⭐ But because of lifetime annotations make the **code more verbose**, in order to make **common patterns** more ergonomic, Rust allows lifetimes to be **elided/omitted** in `fn` definitions. In this case, the compiler assigns lifetime annotations **implicitly**.
 
-Lifetime annotations are **checked at compile-time**. Compiler checks when a data is used for the first and the last times. According to that, Rust manages memory in **run time**. This is the major reason for **slower compilation times** in Rust.
+Lifetime annotations are **checked at compile-time**. The compiler checks when data is used for the first and the last times.
 
-> * Unlike C and C++, **usually**, Rust doesn’t explicitly drop values at all.
+> * Unlike C and C++, **usually**, Rust doesn’t require explicitly dropping values at all.
 > * Unlike GC, Rust doesn’t place deallocation calls where the data is no longer referenced.
 > * Rust places deallocation calls where the data is about to go out of the scope and then enforces that no references to that resource exist after that point.
 


### PR DESCRIPTION
There's a common misconception that the borrow checker contributes
substantially to Rust compilation time. However, this isn't the case;
borrow checking is not a substantial part of compilation time.

(For reference, some of the larger contributors to Rust compilation time
include Rust relying too much on LLVM to clean up and optimize things rather
than sending less LLVM IR to LLVM in the first place. Monomorphization can also
contribute to this problem.)
